### PR TITLE
Fix scan percentage

### DIFF
--- a/pogom/search.py
+++ b/pogom/search.py
@@ -141,7 +141,7 @@ def search(args, i):
             else:
                 log.info('Map Download failed. Trying again.')
 
-        log.info('Completed {:5.2f}% of scan.'.format(float(step) / num_steps**2*100))
+        log.info('Completed {:5.2f}% of scan.'.format(float(step) / total_step*100))
         time.sleep(config['REQ_SLEEP'])
 
 


### PR DESCRIPTION
This pull request includes a fix for calculation of completed scan percentage which was broken. 

For some reason it was step/num_step^2*100 (num_step being the raw step limit away from user and not the number of steps required to scan the lattice).

Now it is (step/total_steps)*100 (Brackets only here for clarification, code doesn't need it because of order of operations

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Changed calculation of percentage
-
-

If this is related to an existing ticket, include a link to it as well.

